### PR TITLE
hack-fixed circular dependency

### DIFF
--- a/src/creep-tasks/Task.ts
+++ b/src/creep-tasks/Task.ts
@@ -12,7 +12,6 @@
  * If you use Traveler, change all occurrences of creep.moveTo() to creep.travelTo()
  */
 
-import {initializeTask} from './utilities/initializer';
 import {deref, derefRoomPosition} from './utilities/helpers';
 
 type targetType = { ref: string, pos: RoomPosition }; // overwrite this variable in derived classes to specify more precise typing
@@ -120,7 +119,7 @@ export abstract class Task implements ITask {
 
 	// Getter/setter for task parent
 	get parent(): Task | null {
-		return (this._parent ? initializeTask(this._parent) : null);
+		return (this._parent ? global.initializeTask(this._parent) : null);
 	}
 
 	set parent(parentTask: Task | null) {

--- a/src/creep-tasks/index.d.ts
+++ b/src/creep-tasks/index.d.ts
@@ -97,3 +97,5 @@ interface RoomPosition {
 
 	availableNeighbors(ignoreCreeps?: boolean): RoomPosition[];
 }
+
+declare const global: any;

--- a/src/creep-tasks/utilities/initializer.ts
+++ b/src/creep-tasks/utilities/initializer.ts
@@ -107,3 +107,4 @@ export function initializeTask(protoTask: protoTask): Task {
 	return task;
 }
 
+global.initializeTask = initializeTask;


### PR DESCRIPTION
## Pull request summary

### Brief description:
When using creep-tasks with Typescript (and webpack), coppied /src/creep-tasks to my project (as per instructions), but was unable to solve this particular circular-dependency. Project compiles just fine, but in-game it throws error.

Tried to modify creep-tasks with Overmind version, because Overmind works, but nothing successful.

When using your rollup config instead of webpack, it doesn't work ingame either. And it prints warning
`(!) Circular dependency: src\creep-tasks\utilities\initializer.ts -> src\creep-tasks\TaskInstances\task_attack.ts -> src\creep-tasks\Task.ts -> src\creep-tasks\utilities\initializer.ts` 
Basically, its only first circular dependency, theese cycles are present for each task type. And its breaking, when there is more than 1 task.
(for webpack, i used https://github.com/aackerman/circular-dependency-plugin which printed one hell of cycles)

### Added features:
Thic PR included somewhat hacky solution for the problem, as i was unable to solve it on the design level.

### Changes to existing features:
<!--- Describe changes to existing features here --->

- None

### Bugfixes: 
<!--- If this fixes an open issue, please include it as "#issueNo" --->

- None


## Testing checklist:
<!--- Fill with [x] for items you have completed. If an item is not applicable or isn't checked, explain why --->

- [ ] Codebase compiles with current `tsconfig` configuration
- [x] Deployed and tested changes 
