### PR TITLE
Get room terrain is deprecated

### DIFF
--- a/bin/creep-tasks.js
+++ b/bin/creep-tasks.js
@@ -1172,8 +1172,12 @@ Object.defineProperty(RoomPosition.prototype, 'neighbors', {
 });
 RoomPosition.prototype.isPassible = function (ignoreCreeps = false) {
     // Is terrain passable?
-    if (Game.map.getTerrainAt(this) == 'wall')
-        return false;
+    //changing this due to screeps api deprecating Game.map.getTerrainAt
+    let terrain = Game.map.getRoomTerrain(this.roomName);
+    if (terrain.get(this.x,this.y) == TERRAIN_MASK_WALL) 
+      return false;
+    //if (Game.map.getTerrainAt(this) == 'wall')
+    //    return false;
     if (this.isVisible) {
         // Are there creeps?
         if (ignoreCreeps == false && this.lookFor(LOOK_CREEPS).length > 0)

--- a/bin/creep-tasks.js
+++ b/bin/creep-tasks.js
@@ -1172,12 +1172,11 @@ Object.defineProperty(RoomPosition.prototype, 'neighbors', {
 });
 RoomPosition.prototype.isPassible = function (ignoreCreeps = false) {
     // Is terrain passable?
-    //changing this due to screeps api deprecating Game.map.getTerrainAt
+    
     let terrain = Game.map.getRoomTerrain(this.roomName);
     if (terrain.get(this.x,this.y) == TERRAIN_MASK_WALL) 
       return false;
-    //if (Game.map.getTerrainAt(this) == 'wall')
-    //    return false;
+    
     if (this.isVisible) {
         // Are there creeps?
         if (ignoreCreeps == false && this.lookFor(LOOK_CREEPS).length > 0)


### PR DESCRIPTION
## Pull request summary
Screeps deprecated Game.map.getRoomTerrainAt. 
### Brief description:
<!--- Include a brief description of the changes in this pull request here --->        
I switched to the new method and changed the check to use a constant rather than the string

### Added features:
<!--- Include new features added with this pull request here --->

- None

### Changes to existing features:
<!--- Describe changes to existing features here --->

- None

### Bugfixes: 
<!--- If this fixes an open issue, please include it as "#issueNo" --->

- None


## Testing checklist:
<!--- Fill with [x] for items you have completed. If an item is not applicable or isn't checked, explain why --->

- [ ] Codebase compiles with current `tsconfig` configuration: didn't change the typescript version
- [x ] Deployed and tested changes 
