### PR TITLE
fix: Replace deprecated methods

### DIFF
--- a/src/creep-tasks/prototypes.ts
+++ b/src/creep-tasks/prototypes.ts
@@ -104,7 +104,7 @@ Object.defineProperty(RoomPosition.prototype, 'neighbors', {
 
 RoomPosition.prototype.isPassible = function (ignoreCreeps = false): boolean {
 	// Is terrain passable?
-	if (Game.map.getTerrainAt(this) == 'wall') return false;
+  if (Game.map.getRoomTerrain(this.roomName).get(this.x, this.y) == TERRAIN_MASK_WALL) {
 	if (this.isVisible) {
 		// Are there creeps?
 		if (ignoreCreeps == false && this.lookFor(LOOK_CREEPS).length > 0) return false;

--- a/src/creep-tasks/prototypes.ts
+++ b/src/creep-tasks/prototypes.ts
@@ -105,6 +105,8 @@ Object.defineProperty(RoomPosition.prototype, 'neighbors', {
 RoomPosition.prototype.isPassible = function (ignoreCreeps = false): boolean {
 	// Is terrain passable?
   if (Game.map.getRoomTerrain(this.roomName).get(this.x, this.y) == TERRAIN_MASK_WALL) {
+    return false;
+  }
 	if (this.isVisible) {
 		// Are there creeps?
 		if (ignoreCreeps == false && this.lookFor(LOOK_CREEPS).length > 0) return false;


### PR DESCRIPTION
```javascript
Game.map.getTerrainAt(x, y, roomName)(pos)
```

>  This method is deprecated and will be removed soon. Please use a faster method Game.map.getRoomTerrain instead.

```javascript
Game.map.getRoomTerrain(roomName)
```


[The document url](https://docs.screeps.com/api/#Game.map.getTerrainAt)